### PR TITLE
Remove non-existing dpd.sig from CMake setup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         version:
           - zeek:7.0
+          - zeek:7.1
           - zeek-dev:latest
 
       fail-fast: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v5.0.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer

--- a/analyzer/CMakeLists.txt
+++ b/analyzer/CMakeLists.txt
@@ -4,4 +4,4 @@ spicy_add_analyzer(
     NAME HTTP
     PACKAGE_NAME HTTP
     SOURCES analyzer.spicy analyzer.evt zeek_analyzer.spicy
-    SCRIPTS dpd.sig __load__.zeek)
+    SCRIPTS __load__.zeek)


### PR DESCRIPTION
The CMake scaffolding ignores non-existing files, but having it present
is still potentially misleading.